### PR TITLE
⭐ Feature: request changed URL when touchUpButton

### DIFF
--- a/Run42SeoulPackage2/Run42SeoulPackage2/Model/URLModel.swift
+++ b/Run42SeoulPackage2/Run42SeoulPackage2/Model/URLModel.swift
@@ -1,0 +1,16 @@
+//
+//  URLModel.swift
+//  Run42SeoulPackage2
+//
+//  Created by 유정현 on 2023/03/06.
+//  Copyright © 2023 Run42. All rights reserved.
+//
+
+import Foundation
+
+struct URLModel {
+	let URLdict = ["42Intra": "https://intra.42.fr",
+				   "Jiphyeonjeon" : "https://42library.kr",
+				   "24Hane": "https://24hoursarenotenough.42seoul.kr",
+				   "80000Coding": "https://80000coding.oopy.io"]
+}

--- a/Run42SeoulPackage2/Run42SeoulPackage2/main/BrowserView.swift
+++ b/Run42SeoulPackage2/Run42SeoulPackage2/main/BrowserView.swift
@@ -10,30 +10,41 @@ import SwiftUI
 import WebKit
 
 struct BrowserView: View {
-    
-    let url: String
-    var body: some View {
-        GeometryReader { g in
-            ScrollView {
-                WebView(url: URL(string: url)!)
-                    .frame(height: g.size.height)
-                    .offset(x: -10, y: -10)
-            }
-            .frame(height: g.size.height)
-        }
-    }
+	
+	@Binding var url: String
+	var webView = WebView(url: URL(string: "https://intra.42.fr")!)
+				
+	var body: some View {
+		GeometryReader { g in
+			ScrollView {
+				webView
+					.frame(height: g.size.height)
+					.offset(x: -10, y: -10)
+			}
+			.frame(height: g.size.height)
+			.onChange(of: url) { newValue in
+				webView.refresh(url: newValue)
+			}
+		}
+	}
 }
 
 struct WebView: NSViewRepresentable {
-    let url: URL
 
-    func makeNSView(context: NSViewRepresentableContext<WebView>) -> WKWebView {
-        let webView: WKWebView = WKWebView()
-        let request = URLRequest(url: self.url)
-        webView.customUserAgent = "Chrome"
-        webView.load(request)
-        return webView
-    }
+	var url: URL
+	let webView: WKWebView = WKWebView()
 
-    func updateNSView(_ webView: WKWebView, context: NSViewRepresentableContext<WebView>) {}
+	func makeNSView(context: NSViewRepresentableContext<WebView>) -> WKWebView {
+		let request = URLRequest(url: self.url)
+		DispatchQueue.main.async {
+			webView.load(request)
+		}
+		return webView
+	}
+	
+	func updateNSView(_ nsView: WKWebView, context: Context) { }
+	
+	func refresh(url: String) {
+		webView.load(URLRequest(url: URL(string: url)!))
+	}
 }

--- a/Run42SeoulPackage2/Run42SeoulPackage2/main/ContentView.swift
+++ b/Run42SeoulPackage2/Run42SeoulPackage2/main/ContentView.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 struct ContentView: View {
-    var body: some View {
-        WindowView()
-            .preferredColorScheme(.dark)
-    }
+	var body: some View {
+		WindowView()
+			.preferredColorScheme(.dark)
+	}
 }
 
 struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
+	static var previews: some View {
+		ContentView()
+	}
 }

--- a/Run42SeoulPackage2/Run42SeoulPackage2/main/MenuButtons.swift
+++ b/Run42SeoulPackage2/Run42SeoulPackage2/main/MenuButtons.swift
@@ -12,42 +12,43 @@ struct MenuButtons: View {
     
     var title: String
     var animation: Namespace.ID
-    @Binding var selected: String
+	let urlmodel = URLModel()
+	@Binding var selected: String
+	@Binding var url: String
     
-    var body: some View {
-        
-        Button {
-            withAnimation(.spring()) {
-                selected = title
-            }
-            
-        } label: {
-            HStack {
-                
-                Text(title)
-                    .fontWeight(selected == title ? .bold : .none)
-                    .foregroundColor(selected == title ? Color.white : Color.white.opacity(0.5))
-                    .animation(.none)
-                Spacer()
-                ZStack {
-                    Capsule()
-                        .fill(Color.clear)
-                        .frame(width: 3, height: 18)
-                    if selected == title {
-                        Capsule()
-                            .fill(Color.white)
-                            .frame(width: 3, height: 18)
-                            .matchedGeometryEffect(id: "Tab", in: animation)
-                    }
-                }
-            }
-            .padding(.leading)
-        }
-        .buttonStyle(PlainButtonStyle())
-        
-    }
+	var body: some View {
+		Button {
+			withAnimation(.spring()) {
+				selected = title
+				url = urlmodel.URLdict[title] ?? "42Intra"
+			}
+		} label: {
+			HStack {
+				
+				Text(title)
+					.fontWeight(selected == title ? .bold : .none)
+					.foregroundColor(selected == title ? Color.white : Color.white.opacity(0.5))
+					.animation(.none)
+				Spacer()
+				ZStack {
+					Capsule()
+						.fill(Color.clear)
+						.frame(width: 3, height: 18)
+					if selected == title {
+						Capsule()
+							.fill(Color.white)
+							.frame(width: 3, height: 18)
+							.matchedGeometryEffect(id: "Tab", in: animation)
+					}
+				}
+			}
+			.padding(.leading)
+		}
+		.buttonStyle(PlainButtonStyle())
+		
+	}
 //    func RedirectURL(url: String) { print("\(url)") }
 //    func LogoList() { print("LogoList") }
 //    func About42Pack() { print("About42Pack") }
-    
+	
 }

--- a/Run42SeoulPackage2/Run42SeoulPackage2/main/Run42SeoulPackage2App.swift
+++ b/Run42SeoulPackage2/Run42SeoulPackage2/main/Run42SeoulPackage2App.swift
@@ -11,9 +11,8 @@ import SwiftUI
 struct Run42SeoulPackage2App: App {
 	@NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 	var body: some Scene {
-		WindowGroup {
-			ContentView()
+		Settings {
+			
 		}
-		.windowStyle(HiddenTitleBarWindowStyle())
 	}
 }

--- a/Run42SeoulPackage2/Run42SeoulPackage2/main/WindowView.swift
+++ b/Run42SeoulPackage2/Run42SeoulPackage2/main/WindowView.swift
@@ -9,88 +9,88 @@
 import SwiftUI
 
 struct WindowView: View {
-    
-    var window = NSScreen.main?.visibleFrame
-    var url: String = "https://intra.42.fr"
-    @State var selected = "42Intra"
-    @Namespace var animation
-    
-    var body: some View {
-        
-        HStack {
-            HStack(spacing: 0) {
-                VStack {
-                    Group {
-                        HStack {
-                            Image("42flip_01")
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 40, height: 40)
-                            Text("Run Pack")
-                                .fontWeight(.bold)
-                                .offset(x: -8)
-                            Spacer(minLength: 0)
-                        }
-                        .padding(.top, 5)
-                        .padding(.leading)
-                        
-                        MenuButtons(title: "42Intra", animation: animation, selected: $selected)
-                        MenuButtons(title: "Jiphhyeonjeon", animation: animation, selected: $selected)
-                        MenuButtons(title: "24Hane", animation: animation, selected: $selected)
-                        MenuButtons(title: "80000Coding", animation: animation, selected: $selected)
-                        Divider().offset(x: -2)
-                        MenuButtons(title: "About", animation: animation, selected: $selected)
-                        MenuButtons(title: "Quit", animation: animation, selected: $selected)
-                    }
+	
+	var window = NSScreen.main?.visibleFrame
+	@State var url: String = "https://intra.42.fr"
+	@State var selected: String = "42Intra"
+	@Namespace var animation
+	
+	var body: some View {
+		
+		HStack {
+			HStack(spacing: 0) {
+				VStack {
+					Group {
+						HStack {
+							Image("42flip_01")
+								.resizable()
+								.aspectRatio(contentMode: .fit)
+								.frame(width: 40, height: 40)
+							Text("Run Pack")
+								.fontWeight(.bold)
+								.offset(x: -8)
+							Spacer(minLength: 0)
+						}
+						.padding(.top, 5)
+						.padding(.leading)
+						
+						MenuButtons(title: "42Intra", animation: animation, selected: $selected, url: $url)
+						MenuButtons(title: "Jiphyeonjeon", animation: animation, selected: $selected, url: $url)
+						MenuButtons(title: "24Hane", animation: animation, selected: $selected, url: $url)
+						MenuButtons(title: "80000Coding", animation: animation, selected: $selected, url: $url)
+						Divider().offset(x: -2)
+						MenuButtons(title: "About", animation: animation, selected: $selected, url: $url)
+						MenuButtons(title: "Quit", animation: animation, selected: $selected, url: $url)
+					}
 
-                    Spacer(minLength: 0)
-                                        
-                    HStack(spacing: 10) {
-                        Image("cat_page1")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 30, height: 30)
-                            .clipShape(Circle())
-                            .offset(x: -15)
-                        VStack(alignment: .leading) {
-                            Text("junyoo")
-                                .font(.caption)
-                                .fontWeight(.semibold)
-                                .foregroundColor(.white)
-                                .offset(x: -15)
-                            Text("c1r1s1")
-                                .font(.caption2)
-                                .fontWeight(.semibold)
-                                .foregroundColor(.white)
-                                .offset(x: -15)
-                        }
-                    }
-                    .background(RoundedRectangle(cornerRadius: 15).fill(Color.white.opacity(0.5))
-                        .frame(width: 130, height: 40)
-                    )
-                    .padding(.bottom, 15)
+					Spacer(minLength: 0)
+										
+					HStack(spacing: 10) {
+						Image("cat_page1")
+							.resizable()
+							.aspectRatio(contentMode: .fit)
+							.frame(width: 30, height: 30)
+							.clipShape(Circle())
+							.offset(x: -15)
+						VStack(alignment: .leading) {
+							Text("junyoo")
+								.font(.caption)
+								.fontWeight(.semibold)
+								.foregroundColor(.white)
+								.offset(x: -15)
+							Text("c1r1s1")
+								.font(.caption2)
+								.fontWeight(.semibold)
+								.foregroundColor(.white)
+								.offset(x: -15)
+						}
+					}
+					.background(RoundedRectangle(cornerRadius: 15).fill(Color.white.opacity(0.5))
+						.frame(width: 130, height: 40)
+					)
+					.padding(.bottom, 15)
 
-                }
+				}
 
-                Divider()
-                    .offset(x: -2)
-            }
-            .frame(width: 160)
-            
-            Spacer()
-            
-            BrowserView(url: url)
-        }
+				Divider()
+					.offset(x: -2)
+			}
+			.frame(width: 160)
+			
+			Spacer()
 
-        .background(Color.white.opacity(0))
-        .frame(width: HostingView().size.width, height: HostingView().size.height)
-    }
+			BrowserView(url: $url)
+		}
 
-    
+		.background(Color.white.opacity(0))
+		.frame(width: window!.width / 2, height: window!.height / 2)
+	}
+
+	
 }
 
 struct WindowView_Previews: PreviewProvider {
-    static var previews: some View {
-        WindowView()
-    }
+	static var previews: some View {
+		WindowView()
+	}
 }


### PR DESCRIPTION
### Description
 - add URLModel dictionary.
 - when touch up button webView the URL will change and reload webView with changed URL.
 
## Proposed changes
 - reload webView with each other Button's URL.

## Changed Files
- [X] Run42SeoulPackage2App.swift
- [X] AppDelegate.swift
- [X] ContentView.swift
- [X] MenuButtons.swift
- [X] WindowView.swift
- [X] BrowserView.swift

## Checklist
- [X] Build Successfully
- [X] Requesting each other Button's URL Successfully

## Postscript
 - *.swift: Update Lint(spaces -> tab).
 - Run42SeoulPackage2App: changed the body scene to hide the ContentView(ContentView -> Settings).
 - the `About` and `Quit` buttons function will update.

## Screenshot
<img width="832" alt="image" src="https://user-images.githubusercontent.com/50796114/222997491-23775748-e7d8-43f5-a1b0-c7314353d517.png">

<img width="832" alt="image" src="https://user-images.githubusercontent.com/50796114/222997527-d80446ea-d759-40ca-90ae-92473324f170.png">

<img width="830" alt="image" src="https://user-images.githubusercontent.com/50796114/222997550-7cdc6d4d-5835-417e-b150-63e28b7393b9.png">

<img width="827" alt="image" src="https://user-images.githubusercontent.com/50796114/222997576-aef6ef5f-06f1-427f-a791-4d20285b3555.png">

